### PR TITLE
Fix windows build issue

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,4 +24,4 @@ before_test:
 
 # to run your custom scripts instead of automatic tests
 test_script:
-  - python src/automate.py
+  - win_runtests.cmd

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,4 +25,3 @@ before_test:
 # to run your custom scripts instead of automatic tests
 test_script:
   - python src/automate.py
-  - exit 0

--- a/src/automate.py
+++ b/src/automate.py
@@ -139,7 +139,7 @@ def run_executable(executable, arguments, plat, driver=None, top_level=True) :
         driver, performance_tear_down = run_executable(executable["tear-down"], arguments, plat, driver, False)
 
     if top_level and plat == "web" :
-        driver.close()
+        driver.quit()
 
     # Its better that each process writes its own performance numbers.
     # Otherwise each process will have to send the data to the parent process. What a pain!

--- a/src/automate.py
+++ b/src/automate.py
@@ -139,7 +139,7 @@ def run_executable(executable, arguments, plat, driver=None, top_level=True) :
         driver, performance_tear_down = run_executable(executable["tear-down"], arguments, plat, driver, False)
 
     if top_level and plat == "web" :
-        driver.quit()
+        driver.close()
 
     # Its better that each process writes its own performance numbers.
     # Otherwise each process will have to send the data to the parent process. What a pain!

--- a/win_runtests.cmd
+++ b/win_runtests.cmd
@@ -1,0 +1,4 @@
+@REM Run tests & clean up
+python src/automate.py
+tasklist | find /i "chromedriver.exe" && taskkill /im chromedriver.exe /F || echo chromedriver is not running.
+echo Finished running tests


### PR DESCRIPTION
Fixes #31 

This issue is specific to appveyor not windows as reported here https://help.appveyor.com/discussions/problems/2590-it-hangs-when-theres-spawned-process-running-in-background. The test_script stage waits for all the process to exit before moving further (chromedriver, in our case). Following the workaround suggested in the link above to cleanup.