### PR TITLE
[t-gok] Support arguments.json along with arguments.txt

### DIFF
--- a/src/automate.py
+++ b/src/automate.py
@@ -191,18 +191,17 @@ def recording_init(suite_name) :
     return suite_path
 
 def get_arguments() :
-    arguments_file_path = ARGUMENTS_FILE
     return_dict = {}
-    if os.path.isfile(arguments_file_path) :
-        with open(arguments_file_path, "r") as args_file :
-            if arguments_file_path.endswith('.json'):
-                return_dict = json.load(args_file)
-                return return_dict
-            else:
-                for line in args_file :
-                    key, value = line.strip("\n").split("=")
-                    return_dict[key] = value
-                return return_dict
+    if os.path.isfile('arguments.json') :
+        with open('arguments.json', "r") as args_file :
+            return_dict = json.load(args_file)
+            return return_dict
+    elif os.path.isfile('arguments.txt') :
+        with open('arguments.txt', "r") as args_file :
+            for line in args_file :
+                key, value = line.strip("\n").split("=")
+                return_dict[key] = value
+            return return_dict
     return return_dict
 
 def run_parallel(runnables, arguments) :

--- a/src/automate.py
+++ b/src/automate.py
@@ -195,10 +195,14 @@ def get_arguments() :
     return_dict = {}
     if os.path.isfile(arguments_file_path) :
         with open(arguments_file_path, "r") as args_file :
-            for line in args_file :
-                key, value = line.strip("\n").split("=")
-                return_dict[key] = value
-            return return_dict
+            if arguments_file_path.endswith('.json'):
+                return_dict = json.load(args_file)
+                return return_dict
+            else:
+                for line in args_file :
+                    key, value = line.strip("\n").split("=")
+                    return_dict[key] = value
+                return return_dict
     return return_dict
 
 def run_parallel(runnables, arguments) :

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,4 +1,3 @@
-ARGUMENTS_FILE = "arguments.txt"
 RECORDINGS_DIR = "recordings"
 RUN_JSON = "suites/run.json"
 PERFORMANCE_DIR = "performance"


### PR DESCRIPTION
PR checklist:

- [x] Make arguments.txt as arguments.json. Support both the data types. #46.
- [x] Code passes cross browser testing.
- [x] Test code coverage is 85% or greater.
- [x] PR branch is up-to-date with latest master branch.
